### PR TITLE
Revert "Bump tracing-subscriber from 0.3.16 to 0.3.17"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",

--- a/crates/repomng/Cargo.toml
+++ b/crates/repomng/Cargo.toml
@@ -13,5 +13,5 @@ git2 = "0.17.1"
 hyper = "0.14.26"
 serde = { version = "1.0.162", features = ["derive"] }
 tokio = { version = "1.28.0", default-features = false, features = ["macros", "rt-multi-thread"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-subscriber = "0.3.17"


### PR DESCRIPTION
Reverts #145 

Fixes #149 